### PR TITLE
Shorten minimum search length to 4 chars

### DIFF
--- a/app/containers/App.js
+++ b/app/containers/App.js
@@ -36,7 +36,7 @@ export default class App extends Component {
   }
 
   search(query) {
-    if (!query || query.length < 5) {
+    if (!query || query.length < 3) {
       return this.setState({
         ...this.state,
         isSearching: false


### PR DESCRIPTION
Five chars seems a little too long - what if someone wants to search for "Ruby"
or "Poe"? Searching when the query is > 3 seems better for now.